### PR TITLE
Fix authentication routing inconsistencies and simplify auth forms

### DIFF
--- a/PROJECT_ANALYSIS.md
+++ b/PROJECT_ANALYSIS.md
@@ -1,0 +1,48 @@
+# Project Analysis: Immigration Storyboard
+
+## Overview
+This repository contains a Next.js App Router application in `ircc-storyboard/` that provides an AI-assisted immigration guidance experience for Canadian IRCC-related workflows.
+
+## Architecture Snapshot
+- **Frontend/UI**: Next.js 15 + React 19 with Tailwind and shadcn-style UI components under `src/components`.
+- **Routing model**:
+  - Public pages (`/`, `/about`, `/contact`, `/knowtheteam`, `/public/auth`)
+  - Protected pages under `/private/*` (`prompt`, `storyboard`, `explore`)
+- **Backend/API**:
+  - `src/app/api/chat/route.ts` calls OpenRouter and expects JSON-array responses.
+  - `src/app/api/auth/[...nextauth]/route.ts` wires NextAuth to Google OAuth.
+- **Persistence**: Prisma + PostgreSQL with a single `User` model currently defined in `prisma/schema.prisma`.
+
+## Key Strengths
+1. **Clear private/public segmentation** via middleware route guarding.
+2. **Reasonable LLM output hardening** with response sanitation and JSON parse checks before returning data to UI.
+3. **Modern stack cohesion** (Next.js App Router + Prisma + NextAuth).
+
+## Notable Issues / Risks
+1. **Auth route mismatch risk**
+   - NextAuth custom sign-in page is configured as `/auth` in `authOptions`, while middleware redirects unauthenticated users to `/public/auth`.
+   - This could lead to inconsistent navigation behavior depending on entry path.
+2. **Lint workflow not bootstrapped for CI**
+   - `npm run lint` opens Next.js interactive ESLint setup prompt because no ESLint config is committed.
+   - This blocks non-interactive CI quality checks.
+3. **Build fragility due to remote Google font fetch**
+   - Production build currently fails in restricted/offline environments because `next/font` fetches Geist fonts at build-time.
+4. **Data model is minimal**
+   - Only `User` exists; no persisted prompt/storyboard/session entities yet, limiting product continuity features (history, saved flows, analytics).
+5. **LLM contract brittleness**
+   - JSON extraction uses regex-based bracket matching; malformed model output could still pass extraction but fail semantics.
+
+## Immediate Recommendations (High Impact)
+1. Unify auth sign-in path configuration between NextAuth and middleware.
+2. Commit an ESLint configuration so `npm run lint` is non-interactive.
+3. Replace remote Google font dependency with a local/self-hosted font strategy for deterministic builds.
+4. Add schema models for `PromptSession` and `StoryboardStep` to support saved user progress.
+5. Add runtime schema validation (e.g., Zod) for LLM response structure before client delivery.
+
+## Developer Experience Notes
+- Top-level `package.json` is lockfile-only metadata; actual app scripts/deps live in `ircc-storyboard/package.json`.
+- Prisma generation currently warns about missing explicit `generator output` (future Prisma 7 compatibility concern).
+
+## Validation Performed
+- Attempted lint (`npm run lint`) -> blocked by interactive ESLint initialization prompt.
+- Attempted production build (`npm run build`) -> failed due to inability to fetch Geist fonts from Google.

--- a/ircc-storyboard/src/app/about/page.tsx
+++ b/ircc-storyboard/src/app/about/page.tsx
@@ -114,7 +114,7 @@ export default function AboutPage() {
               Ready to Start Your Journey?
             </h2>
             <button
-              onClick={() => router.push('/auth')}
+              onClick={() => router.push('/public/auth')}
               className="bg-blue-600 hover:bg-blue-700 text-white font-medium py-3 px-8 rounded-lg inline-flex items-center transition-colors"
             >
               Get Started Now

--- a/ircc-storyboard/src/app/private/prompt/page.tsx
+++ b/ircc-storyboard/src/app/private/prompt/page.tsx
@@ -30,7 +30,7 @@ export default function PromptPage() {
 
   useEffect(() => {
     if (status === "unauthenticated") {
-      router.push("/auth");
+      router.push("/public/auth");
     }
   }, [status, router]);
 

--- a/ircc-storyboard/src/app/public/auth/LoginForm.tsx
+++ b/ircc-storyboard/src/app/public/auth/LoginForm.tsx
@@ -1,66 +1,19 @@
 import React from 'react'
-import { useRouter } from 'next/navigation';
 import { signIn } from 'next-auth/react'
 
-
 export const LoginForm = () => {
-  const router = useRouter()
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault()
-    // Add authentication logic here
-    router.push('/private/storyboard')
-  }
-  // Inside your component
-<button
-  onClick={() => signIn('google')}
-  className="w-full py-2 mt-4 bg-red-500 text-white rounded hover:bg-red-600 transition-colors"
->
-  Continue with Google
-</button>
-
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <div>
-        <label
-          htmlFor="email"
-          className="block text-sm font-medium text-gray-700 mb-1"
-        >
-          Email
-        </label>
-        <input
-          type="email"
-          id="email"
-          className="w-full px-4 py-2 rounded-lg border border-gray-300 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-          placeholder="Enter your email"
-          required
-        />
-      </div>
-      <div>
-        <label
-          htmlFor="password"
-          className="block text-sm font-medium text-gray-700 mb-1"
-        >
-          Password
-        </label>
-        <input
-          type="password"
-          id="password"
-          className="w-full px-4 py-2 rounded-lg border border-gray-300 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-          placeholder="Enter your password"
-          required
-        />
-      </div>
-      <div className="text-right">
-        <a href="#" className="text-sm text-blue-600 hover:text-blue-800">
-          Forgot Password?
-        </a>
-      </div>
+    <div className="space-y-4">
+      <p className="text-sm text-gray-600 text-center">
+        This app currently supports Google authentication.
+      </p>
       <button
-        type="submit"
-        className="w-full bg-blue-600 hover:bg-blue-700 text-white font-medium py-2.5 px-4 rounded-lg transition-colors"
+        type="button"
+        onClick={() => signIn('google', { callbackUrl: '/private/prompt' })}
+        className="w-full py-2 mt-2 bg-red-500 text-white rounded hover:bg-red-600 transition-colors"
       >
-        Log In
+        Continue with Google
       </button>
-    </form>
+    </div>
   )
 }

--- a/ircc-storyboard/src/app/public/auth/SignUpForm.tsx
+++ b/ircc-storyboard/src/app/public/auth/SignUpForm.tsx
@@ -1,65 +1,19 @@
 import React from 'react'
-import { useRouter } from 'next/navigation';
+import { signIn } from 'next-auth/react'
+
 export const SignupForm = () => {
-  const router = useRouter()
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault()
-    // Add signup logic here
-    router.push('/dashboard')
-  }
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <div>
-        <label
-          htmlFor="name"
-          className="block text-sm font-medium text-gray-700 mb-1"
-        >
-          First Name
-        </label>
-        <input
-          type="text"
-          id="name"
-          className="w-full px-4 py-2 rounded-lg border border-gray-300 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-          placeholder="Enter your first name"
-          required
-        />
-      </div>
-      <div>
-        <label
-          htmlFor="signup-email"
-          className="block text-sm font-medium text-gray-700 mb-1"
-        >
-          Email
-        </label>
-        <input
-          type="email"
-          id="signup-email"
-          className="w-full px-4 py-2 rounded-lg border border-gray-300 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-          placeholder="Enter your email"
-          required
-        />
-      </div>
-      <div>
-        <label
-          htmlFor="signup-password"
-          className="block text-sm font-medium text-gray-700 mb-1"
-        >
-          Password
-        </label>
-        <input
-          type="password"
-          id="signup-password"
-          className="w-full px-4 py-2 rounded-lg border border-gray-300 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-          placeholder="Create a password"
-          required
-        />
-      </div>
+    <div className="space-y-4">
+      <p className="text-sm text-gray-600 text-center">
+        New accounts are created automatically when you sign in with Google.
+      </p>
       <button
-        type="submit"
+        type="button"
+        onClick={() => signIn('google', { callbackUrl: '/private/prompt' })}
         className="w-full bg-blue-600 hover:bg-blue-700 text-white font-medium py-2.5 px-4 rounded-lg transition-colors"
       >
-        Create Account
+        Sign up with Google
       </button>
-    </form>
+    </div>
   )
 }

--- a/ircc-storyboard/src/app/public/auth/page.tsx
+++ b/ircc-storyboard/src/app/public/auth/page.tsx
@@ -5,7 +5,6 @@ import { LoginForm } from '@/app/public/auth/LoginForm'
 import { SignupForm } from '@/app/public/auth/SignUpForm'
 import { MapPinIcon, ArrowLeftIcon } from 'lucide-react'
 import { useRouter } from 'next/navigation'
-import { signIn } from 'next-auth/react'
 
 export default function AuthPage() {
   const [activeTab, setActiveTab] = useState<'login' | 'signup'>('login')
@@ -61,13 +60,6 @@ export default function AuthPage() {
         <div className="transition-opacity duration-200">
           {activeTab === 'login' ? <LoginForm /> : <SignupForm />}
         </div>
-
-        <button
-  onClick={() => signIn('google', { callbackUrl: '/private/prompt' })}
-  className="w-full py-2 mt-4 bg-red-500 text-white rounded hover:bg-red-600 transition-colors"
->
-  Continue with Google
-</button>
       </div>
     </div>
   )

--- a/ircc-storyboard/src/components/navbar.tsx
+++ b/ircc-storyboard/src/components/navbar.tsx
@@ -26,13 +26,13 @@ export default function Navbar() {
             </span>
             <Button
               variant="destructive"
-              onClick={() => signOut({ callbackUrl: "/auth" })}
+              onClick={() => signOut({ callbackUrl: "/public/auth" })}
             >
               Sign Out
             </Button>
           </>
         ) : (
-          <Link href="/auth">
+          <Link href="/public/auth">
             <Button>Sign In</Button>
           </Link>
         )}

--- a/ircc-storyboard/src/lib/authOptions.ts
+++ b/ircc-storyboard/src/lib/authOptions.ts
@@ -1,7 +1,6 @@
-
-import GoogleProvider from "next-auth/providers/google"
-import { NextAuthOptions } from "next-auth"
-import { prisma } from "@/lib/prisma" // Make sure this path is correct
+import GoogleProvider from "next-auth/providers/google";
+import { NextAuthOptions } from "next-auth";
+import { prisma } from "@/lib/prisma";
 
 export const authOptions: NextAuthOptions = {
   providers: [
@@ -10,41 +9,44 @@ export const authOptions: NextAuthOptions = {
       clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
       authorization: {
         params: {
-          scope: 'openid email profile',
-        }
-      }
+          scope: "openid email profile",
+        },
+      },
     }),
   ],
   secret: process.env.NEXTAUTH_SECRET,
   pages: {
-    signIn: "/auth",
+    signIn: "/public/auth",
   },
   callbacks: {
     async signIn({ user }) {
+      if (!user.email) return false;
+
       try {
         const existingUser = await prisma.user.findUnique({
-          where: { email: user.email! },
-        })
+          where: { email: user.email },
+        });
 
         if (!existingUser) {
           await prisma.user.create({
             data: {
               name: user.name,
-              email: user.email!,
+              email: user.email,
               image: user.image,
             },
-          })
+          });
         }
 
-        return true
+        return true;
       } catch (error) {
-        console.error("SignIn error:", error)
-        return false
+        console.error("SignIn error:", error);
+        return false;
       }
     },
     async redirect({ url, baseUrl }) {
-      return "/private/prompt"
+      if (url.startsWith("/")) return `${baseUrl}${url}`;
+      if (url.startsWith(baseUrl)) return url;
+      return `${baseUrl}/private/prompt`;
     },
   },
-}
-
+};


### PR DESCRIPTION
### Motivation
- Unify the sign-in route and client redirects so unauthenticated users reliably land on the app's public sign-in page instead of mismatched paths. 
- Ensure NextAuth redirects and signIn callbacks behave safely with the configured Google provider and the Prisma user store. 
- Remove misleading email/password UI that does not match the configured authentication method. 

### Description
- Standardized the sign-in route to `/public/auth` across NextAuth `pages.signIn`, client-side redirects, navbar links, and CTA buttons. 
- Hardened `authOptions` callbacks by rejecting sign-ins with missing email, using safe `prisma` lookups/creates, and implementing a `redirect` callback that respects relative and base URLs and otherwise defaults to `/private/prompt`. 
- Replaced the previous email/password form markup with concise Google OAuth buttons and explanatory text in `LoginForm` and `SignupForm`, and removed a duplicated global Google sign-in button from the auth page. 
- Updated protected-page client redirects to `router.push('/public/auth')` so middleware and UI are consistent. 

### Testing
- Ran `cd ircc-storyboard && npx tsc --noEmit` to verify TypeScript compilation, which passed. 
- Launched the dev server and used a Playwright script to visit `http://127.0.0.1:3000/public/auth` and capture a screenshot to validate the updated auth UI, which succeeded. 
- Note: prior build/lint issues (interactive ESLint bootstrap and remote font fetch during `next build`) remain unrelated to these auth changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aeee9334c8321988f728d8984055e)