### PR TITLE
Fix NextAuth sign-in route mismatch causing post-login 404

### DIFF
--- a/ircc-storyboard/src/app/about/page.tsx
+++ b/ircc-storyboard/src/app/about/page.tsx
@@ -114,7 +114,7 @@ export default function AboutPage() {
               Ready to Start Your Journey?
             </h2>
             <button
-              onClick={() => router.push('/auth')}
+              onClick={() => router.push('/public/auth')}
               className="bg-blue-600 hover:bg-blue-700 text-white font-medium py-3 px-8 rounded-lg inline-flex items-center transition-colors"
             >
               Get Started Now

--- a/ircc-storyboard/src/app/auth/page.tsx
+++ b/ircc-storyboard/src/app/auth/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function AuthRedirectPage() {
+  redirect("/public/auth");
+}

--- a/ircc-storyboard/src/app/private/prompt/page.tsx
+++ b/ircc-storyboard/src/app/private/prompt/page.tsx
@@ -30,7 +30,7 @@ export default function PromptPage() {
 
   useEffect(() => {
     if (status === "unauthenticated") {
-      router.push("/auth");
+      router.push("/public/auth");
     }
   }, [status, router]);
 

--- a/ircc-storyboard/src/components/navbar.tsx
+++ b/ircc-storyboard/src/components/navbar.tsx
@@ -26,13 +26,13 @@ export default function Navbar() {
             </span>
             <Button
               variant="destructive"
-              onClick={() => signOut({ callbackUrl: "/auth" })}
+              onClick={() => signOut({ callbackUrl: "/public/auth" })}
             >
               Sign Out
             </Button>
           </>
         ) : (
-          <Link href="/auth">
+          <Link href="/public/auth">
             <Button>Sign In</Button>
           </Link>
         )}

--- a/ircc-storyboard/src/lib/authOptions.ts
+++ b/ircc-storyboard/src/lib/authOptions.ts
@@ -17,7 +17,7 @@ export const authOptions: NextAuthOptions = {
   ],
   secret: process.env.NEXTAUTH_SECRET,
   pages: {
-    signIn: "/auth",
+    signIn: "/public/auth",
   },
   callbacks: {
     async signIn({ user }) {
@@ -47,4 +47,3 @@ export const authOptions: NextAuthOptions = {
     },
   },
 }
-


### PR DESCRIPTION
### Motivation
- The app was configured to use `/public/auth` for the actual login page but NextAuth and several UI links still referenced `/auth`, causing 404s and sign-in loops after Google login or sign-out.
- Provide a backward-compatible `/auth` entry so legacy callback URLs or external links do not break the auth flow.

### Description
- Updated NextAuth sign-in page to `pages.signIn: "/public/auth"` in `src/lib/authOptions.ts` to match the UI.
- Changed sign-in and sign-out navigation links and callback URLs in `src/components/navbar.tsx` to use `/public/auth`.
- Updated unauthenticated redirect in the protected prompt page at `src/app/private/prompt/page.tsx` to route to `/public/auth` instead of `/auth`.
- Updated CTA on `src/app/about/page.tsx` to use `/public/auth` and added a redirect page at `src/app/auth/page.tsx` that forwards `/auth` to `/public/auth` for compatibility.

### Testing
- Ran `npm run lint`, but it required interactive ESLint initialization in this environment and could not complete (interactive prompt observed). 
- Ran `npm run build`, which reached Next.js build but failed due to inability to fetch Google Fonts (`Geist`/`Geist Mono`) from `https://fonts.googleapis.com` in this environment, so compilation did not finish. 
- Verified code changes locally via static diff inspection and ensured routing references are consistently updated to `/public/auth` and a redirect exists at `/auth`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d772e3a2483219f934333a599a00f)