### PR TITLE
Fix Google AccessDenied by decoupling DB sync from sign-in and showing auth errors

### DIFF
--- a/ircc-storyboard/src/app/about/page.tsx
+++ b/ircc-storyboard/src/app/about/page.tsx
@@ -114,7 +114,7 @@ export default function AboutPage() {
               Ready to Start Your Journey?
             </h2>
             <button
-              onClick={() => router.push('/auth')}
+              onClick={() => router.push('/public/auth')}
               className="bg-blue-600 hover:bg-blue-700 text-white font-medium py-3 px-8 rounded-lg inline-flex items-center transition-colors"
             >
               Get Started Now

--- a/ircc-storyboard/src/app/auth/page.tsx
+++ b/ircc-storyboard/src/app/auth/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function AuthRedirectPage() {
+  redirect("/public/auth");
+}

--- a/ircc-storyboard/src/app/private/prompt/page.tsx
+++ b/ircc-storyboard/src/app/private/prompt/page.tsx
@@ -30,7 +30,7 @@ export default function PromptPage() {
 
   useEffect(() => {
     if (status === "unauthenticated") {
-      router.push("/auth");
+      router.push("/public/auth");
     }
   }, [status, router]);
 

--- a/ircc-storyboard/src/app/public/auth/page.tsx
+++ b/ircc-storyboard/src/app/public/auth/page.tsx
@@ -4,12 +4,24 @@ import { useState } from 'react'
 import { LoginForm } from '@/app/public/auth/LoginForm'
 import { SignupForm } from '@/app/public/auth/SignUpForm'
 import { MapPinIcon, ArrowLeftIcon } from 'lucide-react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { signIn } from 'next-auth/react'
+
+const authErrorMessages: Record<string, string> = {
+  AccessDenied: 'Google login was rejected. Please try again in a few seconds.',
+  OAuthCallback: 'Google callback failed. Check your Google OAuth redirect URI settings.',
+  OAuthSignin: 'Could not start Google login. Please try again.',
+  Configuration: 'Authentication is misconfigured. Please contact support.',
+}
 
 export default function AuthPage() {
   const [activeTab, setActiveTab] = useState<'login' | 'signup'>('login')
   const router = useRouter()
+  const searchParams = useSearchParams()
+  const errorCode = searchParams.get('error')
+  const errorMessage = errorCode
+    ? authErrorMessages[errorCode] ?? 'Authentication failed. Please try signing in again.'
+    : null
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-white py-16 px-4">
@@ -34,6 +46,12 @@ export default function AuthPage() {
         <p className="text-center text-gray-600 mb-8">
           Log in or sign up to begin your personalized journey.
         </p>
+
+        {errorMessage && (
+          <div className="mb-5 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {errorMessage}
+          </div>
+        )}
 
         <div className="flex mb-8">
           <button
@@ -63,11 +81,11 @@ export default function AuthPage() {
         </div>
 
         <button
-  onClick={() => signIn('google', { callbackUrl: '/private/prompt' })}
-  className="w-full py-2 mt-4 bg-red-500 text-white rounded hover:bg-red-600 transition-colors"
->
-  Continue with Google
-</button>
+          onClick={() => signIn('google', { callbackUrl: '/private/prompt' })}
+          className="w-full py-2 mt-4 bg-red-500 text-white rounded hover:bg-red-600 transition-colors"
+        >
+          Continue with Google
+        </button>
       </div>
     </div>
   )

--- a/ircc-storyboard/src/components/navbar.tsx
+++ b/ircc-storyboard/src/components/navbar.tsx
@@ -26,13 +26,13 @@ export default function Navbar() {
             </span>
             <Button
               variant="destructive"
-              onClick={() => signOut({ callbackUrl: "/auth" })}
+              onClick={() => signOut({ callbackUrl: "/public/auth" })}
             >
               Sign Out
             </Button>
           </>
         ) : (
-          <Link href="/auth">
+          <Link href="/public/auth">
             <Button>Sign In</Button>
           </Link>
         )}

--- a/ircc-storyboard/src/lib/authOptions.ts
+++ b/ircc-storyboard/src/lib/authOptions.ts
@@ -1,7 +1,6 @@
-
 import GoogleProvider from "next-auth/providers/google"
 import { NextAuthOptions } from "next-auth"
-import { prisma } from "@/lib/prisma" // Make sure this path is correct
+import { prisma } from "@/lib/prisma"
 
 export const authOptions: NextAuthOptions = {
   providers: [
@@ -10,41 +9,53 @@ export const authOptions: NextAuthOptions = {
       clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
       authorization: {
         params: {
-          scope: 'openid email profile',
-        }
-      }
+          scope: "openid email profile",
+        },
+      },
     }),
   ],
   secret: process.env.NEXTAUTH_SECRET,
   pages: {
-    signIn: "/auth",
+    signIn: "/public/auth",
+    error: "/public/auth",
   },
   callbacks: {
     async signIn({ user }) {
       try {
-        const existingUser = await prisma.user.findUnique({
-          where: { email: user.email! },
-        })
-
-        if (!existingUser) {
-          await prisma.user.create({
-            data: {
+        if (user.email) {
+          await prisma.user.upsert({
+            where: { email: user.email },
+            update: {
               name: user.name,
-              email: user.email!,
+              image: user.image,
+            },
+            create: {
+              name: user.name,
+              email: user.email,
               image: user.image,
             },
           })
+        } else {
+          console.warn("Google sign-in succeeded without an email claim")
         }
-
-        return true
       } catch (error) {
-        console.error("SignIn error:", error)
-        return false
+        // Do not block OAuth login when DB sync fails (e.g. transient DB outage)
+        console.error("User profile sync failed during sign-in:", error)
       }
+
+      return true
     },
     async redirect({ url, baseUrl }) {
-      return "/private/prompt"
+      if (url.startsWith("/")) return `${baseUrl}${url}`
+
+      try {
+        const parsedUrl = new URL(url)
+        if (parsedUrl.origin === baseUrl) return url
+      } catch {
+        // ignore invalid callback URL
+      }
+
+      return `${baseUrl}/private/prompt`
     },
   },
 }
-


### PR DESCRIPTION
### Motivation
- Users were sent to `/api/auth/error?error=AccessDenied` after a successful Google OAuth flow because the `signIn` callback returned `false` when Prisma persistence failed.  
- The auth UX lacked actionable feedback when NextAuth surfaced errors, making failures opaque to end users.  
- Improve resilience so transient DB problems do not prevent OAuth logins while returning users to the app's login UI for error messaging.  

### Description
- Updated `src/lib/authOptions.ts` to stop blocking sign-in on DB sync failures by using `prisma.user.upsert` and logging errors instead of returning `false`, and to always return `true` from the `signIn` callback.  
- Added `pages.error = "/public/auth"` to `authOptions` so NextAuth error routes redirect back to the app's login page.  
- Hardened the `redirect` callback in `authOptions` to allow safe relative paths and trusted absolute callback URLs, with a default fallback to `/private/prompt`.  
- Updated `src/app/public/auth/page.tsx` to read `?error=` query strings and display friendly messages for known NextAuth error codes (e.g. `AccessDenied`, `OAuthCallback`, `OAuthSignin`, `Configuration`).  

### Testing
- Ran `npx tsc --noEmit`, which completed successfully.  
- Started the dev server with `npm run dev` and Next.js compiled and became ready for manual verification.  
- Attempted an automated Playwright screenshot to verify the `/public/auth?error=AccessDenied` UI, but the Chromium process crashed with a SIGSEGV in this environment so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d772e3a2483219f934333a599a00f)